### PR TITLE
feat: add attach remote configuration

### DIFF
--- a/src/EggDebugger.ts
+++ b/src/EggDebugger.ts
@@ -42,6 +42,16 @@ export function init(context: ExtensionContext) {
           "runtimeArgs": ["run", "test-local", "--", "--inspect-brk"],
           "protocol": "auto",
           "port": 9229
+        },
+        {
+          "type": "node",
+          "request": "attach",
+          "name": "Egg Attach to remote",
+          "localRoot": "${workspaceRoot}",
+          "remoteRoot": "/usr/src/app",
+          "address": "localhost",
+          "protocol": "auto",
+          "port": 9999
         }
       ];
     },


### PR DESCRIPTION
1. run `npm run debug` in terminal of remote
2. change `remoteRoot` and `address` of the `Egg Attach to remote` configuration according to the remote app.
3. press F5 in vscode to run `Egg Attach to remote`